### PR TITLE
Replace int with float in get_sensor_value()

### DIFF
--- a/modules/core/core.py
+++ b/modules/core/core.py
@@ -173,7 +173,7 @@ class SensorAPI(object):
     def get_sensor_value(self, id):
         try:
             id = int(id)
-            return int(self.cache.get("sensors")[id].instance.last_value)
+            return float(self.cache.get("sensors")[id].instance.last_value)
         except Exception as e:
 
             return None


### PR DESCRIPTION
I've noticed that sensor values are being handled as integers by this function, which was causing poor performance of the PIDArduino logic and another logic plugin I am testing.  I have changed the type to float, and now logic controllers can receive more accurate temperature values.