### PR TITLE
Move buzzer init order to fall after config init.

### DIFF
--- a/modules/buzzer/__init__.py
+++ b/modules/buzzer/__init__.py
@@ -41,7 +41,7 @@ class Buzzer(object):
 
         start_new_thread(play, (self.sound,))
 
-@cbpi.initalizer(order=0)
+@cbpi.initalizer(order=1)
 def init(cbpi):
     gpio = cbpi.get_config_parameter("buzzer", 16)
     cbpi.buzzer = Buzzer(gpio)

--- a/modules/config/__init__.py
+++ b/modules/config/__init__.py
@@ -52,7 +52,7 @@ class ConfigView(BaseView):
                 cls.post_init_callback(value)
                 cls.api.cache[cls.cache_key][value.name] = value
 
-@cbpi.initalizer(order=1)
+@cbpi.initalizer(order=0)
 def init(cbpi):
     print "INITIALIZE CONFIG MODULE"
     ConfigView.register(cbpi.app, route_base='/api/config')


### PR DESCRIPTION
Buzzer can't initialise with correct gpio pin as the config hasn't been initialised yet.  Fixes issue #52