### PR TITLE
Add reset to post put call (Fermenter update)

### DIFF
--- a/modules/fermenter/__init__.py
+++ b/modules/fermenter/__init__.py
@@ -77,6 +77,7 @@ class FermenterView(BaseView):
 
     def _post_put_callback(self, m):
         m.state = False
+        self.reset(int(m.id))
 
     @route('/<int:id>/targettemp/<temp>', methods=['POST'])
     def postTargetTemp(self, id, temp):


### PR DESCRIPTION
Added a call to reset the fermenter after an update. Possible fix for issue #104

Reset builds step parameter with FerementerStep objects from database.
Reset all clears current ferment steps - this may be positive or negative