### PR TITLE
GPIOPWM: Fixed misleading label and support decimal frequencies

### DIFF
--- a/modules/base_plugins/gpio_actor/__init__.py
+++ b/modules/base_plugins/gpio_actor/__init__.py
@@ -36,10 +36,10 @@ class GPIOSimple(ActorBase):
 class GPIOPWM(ActorBase):
 
     gpio = Property.Select("GPIO", options=[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27], description="GPIO to which the actor is connected")
-    duty_cylce = Property.Number("Duty Cycle", configurable=True)
+    frequency = Property.Number("Frequency (Hz)", configurable=True)
 
     p = None
-    power = 100
+    power = 100  # duty cycle
 
     def init(self):
         GPIO.setup(int(self.gpio), GPIO.OUT)
@@ -50,10 +50,10 @@ class GPIOPWM(ActorBase):
         if power is not None:
             self.power = int(power)
 
-        if self.duty_cylce is None:
-            duty_cylce = 50
+        if self.frequency is None:
+            self.frequency = 0.5  # 2 sec
 
-        self.p = GPIO.PWM(int(self.gpio), int(self.duty_cylce))
+        self.p = GPIO.PWM(int(self.gpio), float(self.frequency))
         self.p.start(int(self.power))
 
     def set_power(self, power):


### PR DESCRIPTION
Fixed misleading label "duty cycle" to "Frequency (Hz)" in GPIOPWM actor config. The intended duty cycle is determined by the **power** of the actor (0-100%). See issue #21

Frequency can now be a decimal value (was previously rounded up when cast to an int). This makes it possible to use small frequencies, for instance 0.1Hz --> 10sec

Tested working with RPI.GPIO PWM implementation. See discussion in issue #121 