### PR TITLE
Revert 142 revert 105 patch2 INDENTATION ERROR FIXED

### DIFF
--- a/modules/base_plugins/brew_steps/__init__.py
+++ b/modules/base_plugins/brew_steps/__init__.py
@@ -160,16 +160,18 @@ class BoilStep(StepBase):
     temp = Property.Number("Temperature", configurable=True, default_value=100, description="Target temperature for boiling")
     kettle = StepProperty.Kettle("Kettle", description="Kettle in which the boiling step takes place")
     timer = Property.Number("Timer in Minutes", configurable=True, default_value=90, description="Timer is started when target temperature is reached")
-    hop_1 = Property.Number("Hop 1 Addition", configurable=True, description="Fist Hop alert")
+    hop_1 = Property.Number("Hop 1 Addition", configurable=True, description="First Hop alert")
     hop_1_added = Property.Number("",default_value=None)
     hop_2 = Property.Number("Hop 2 Addition", configurable=True, description="Second Hop alert")
     hop_2_added = Property.Number("", default_value=None)
-    hop_3 = Property.Number("Hop 3 Addition", configurable=True)
-    hop_3_added = Property.Number("", default_value=None, description="Third Hop alert")
-    hop_4 = Property.Number("Hop 4 Addition", configurable=True)
-    hop_4_added = Property.Number("", default_value=None, description="Fourth Hop alert")
-    hop_5 = Property.Number("Hop 5 Addition", configurable=True)
-    hop_5_added = Property.Number("", default_value=None, description="Fives Hop alert")
+    hop_3 = Property.Number("Hop 3 Addition", configurable=True, description="Third Hop alert")
+    hop_3_added = Property.Number("", default_value=None)
+    hop_4 = Property.Number("Hop 4 Addition", configurable=True, description="Fourth Hop alert")
+    hop_4_added = Property.Number("", default_value=None)
+    hop_5 = Property.Number("Hop 5 Addition", configurable=True, description="Fifth Hop alert")
+    hop_5_added = Property.Number("", default_value=None)
+    fining = Property.Number("Fining Addition", configurable=True, default_value=15)
+    fining_added = Property.Number("",default_value=None, description="Fining Agent Alert")
 
     def init(self):
         '''
@@ -202,10 +204,17 @@ class BoilStep(StepBase):
 
     def check_hop_timer(self, number, value):
 
-        if self.__getattribute__("hop_%s_added" % number) is not True and time.time() > (
-            self.timer_end - (int(self.timer) * 60 - int(value) * 60)):
+        if self.__getattribute__("hop_%s_added" % number) is not True and (int(value) * 60) == (
+            self.timer_end - int(time.time())):
             self.__setattr__("hop_%s_added" % number, True)
             self.notify("Hop Alert", "Please add Hop %s" % number, timeout=None)
+
+    def check_fining_timer(self, value):
+
+        if self.__getattribute__("fining_added") is not True and (int(value) * 60) == (
+            self.timer_end - int(time.time())):
+            self.__setattr__("fining_added", True)
+            self.notify("Fining Alert", "Please add fining agent", timeout=None)
 
     def execute(self):
         '''
@@ -216,6 +225,7 @@ class BoilStep(StepBase):
         if self.get_kettle_temp(self.kettle) >= float(self.temp):
             # Check if Timer is Running
             if self.is_timer_finished() is None:
+                self.notify("Boil Temp Reached", "Starting the boil timer")
                 self.start_timer(int(self.timer) * 60)
             else:
                 self.check_hop_timer(1, self.hop_1)
@@ -223,6 +233,8 @@ class BoilStep(StepBase):
                 self.check_hop_timer(3, self.hop_3)
                 self.check_hop_timer(4, self.hop_4)
                 self.check_hop_timer(5, self.hop_5)
+                self.check_fining_timer(self.fining)
+
         # Check if timer finished and go to next step
         if self.is_timer_finished() == True:
             self.notify("Boil Step Completed!", "Starting the next step", timeout=None)


### PR DESCRIPTION
This fixes the indentation error in PR#105!  This has been tested and is working on my system.

The file changes are listed below for the boilstep:

1. Fining alert to the boil step
2. An alert when the step temp (i.e. boil temp) is reached and timeouts out after 5 sec's
3. Fining and hop alert values reflect what recipes typically indicate (i.e. 60 minute would be the first hop addition in 60 minute boil, 0 minutes would be the last hop addition in a 60 minute boil)
4. Fining description moved

File changes are listed below for the beerxml recipe import:

1. Adds mashin step to the beerxml recipe import
2. Utilizes the default_mashinstep_type config parameter
3. Inputs the infuse_temp (strike temp) from the beerxml file into the mashin step
4. Places the boil step above the chill and whirlpool steps. The previous commit did not actual reorder the steps as described. The error has been corrected as 9/9/17.