### PR TITLE
Make db_location overridable via environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-FROM python:2.7
-
-COPY . /app
-
-WORKDIR app
-
-RUN pip install -r requirements.txt
-
-ENTRYPOINT [ "python", "run.py" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:2.7
+
+COPY . /app
+
+WORKDIR app
+
+RUN pip install -r requirements.txt
+
+ENTRYPOINT [ "python", "run.py" ]

--- a/modules/core/db.py
+++ b/modules/core/db.py
@@ -1,7 +1,9 @@
 import sqlite3
-
+import os
 from flask import json, g
 
+db_root=os.getenv("DB_ROOT", "")
+db_location=db_root + '/craftbeerpi.db'
 
 def get_db():
     db = getattr(g, '_database', None)
@@ -11,7 +13,7 @@ def get_db():
             for idx, col in enumerate(cursor.description):
                 d[col[0]] = row[idx]
             return d
-        db = g._database = sqlite3.connect('craftbeerpi.db')
+        db = g._database = sqlite3.connect(db_location)
         db.row_factory = dict_factory
     return db
 

--- a/modules/core/db_mirgrate.py
+++ b/modules/core/db_mirgrate.py
@@ -1,14 +1,14 @@
 import sqlite3
 import os
 from modules import  cbpi
-from db import get_db
+from db import get_db, db_location
 
 def execute_file(curernt_version, data):
     if curernt_version >= data["version"]:
         cbpi.app.logger.info("SKIP DB FILE: %s" % data["file"])
         return
     try:
-        with sqlite3.connect("craftbeerpi.db") as conn:
+        with sqlite3.connect(db_location) as conn:
             with open('./update/%s' % data["file"], 'r') as f:
                 d = f.read()
                 sqlCommands = d.split(";")


### PR DESCRIPTION
This change will allow people to set the DB_ROOT environment variable on their system to override the location of the database, this would be handy for people that want to be able to store their db outside of the cbpi folder making it easier to remove the folder without loosing the database.

Another usecase is that this could be used to run the application inside docker for those people like myself who use completely http based systems where the application controls no actors itself