### PR TITLE
Add support to DietPi

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,10 @@ show_menu () {
 
            fi
 
-           sudo mv ./config/splash.png /usr/share/plymouth/themes/pix/splash.png
+           # checking for file splash.png
+           if [ -e /usr/share/plymouth/themes/pix/splash.png ]; then
+            sudo mv ./config/splash.png /usr/share/plymouth/themes/pix/splash.png
+           fi
 
            sed "s@#DIR#@${PWD}@g" config/craftbeerpiboot > /etc/init.d/craftbeerpiboot
            chmod 755 /etc/init.d/craftbeerpiboot;

--- a/install.sh
+++ b/install.sh
@@ -43,6 +43,9 @@ show_menu () {
              rm -rf wiringPi;
            fi
 
+           # By default DietPi does not have this package installed.
+           apt-get -y install build-essential
+
            apt-get -y install python-setuptools
            easy_install pip
            apt-get -y install python-dev
@@ -52,9 +55,13 @@ show_menu () {
            confirmAnswer "Would you like to add active 1-wire support at your Raspberry PI now? IMPORTANT: The 1-wire thermometer must be conneted to GPIO 4!"
            if [ $? = 0 ]; then
              #apt-get -y update; apt-get -y upgrade;
-             echo '# CraftBeerPi 1-wire support' >> "/boot/config.txt"
-             echo 'dtoverlay=w1-gpio,gpiopin=4,pullup=on' >> "/boot/config.txt"
-
+             if [ -e /DietPi/config.txt ]; then
+                 echo '# CraftBeerPi 1-wire support' >> "/DietPi/config.txt"
+                 echo 'dtoverlay=w1-gpio,gpiopin=4,pullup=on' >> "/DietPi/config.txt"
+             else
+                 echo '# CraftBeerPi 1-wire support' >> "/boot/config.txt"
+                 echo 'dtoverlay=w1-gpio,gpiopin=4,pullup=on' >> "/boot/config.txt"
+             fi
            fi
 
            # checking for file splash.png


### PR DESCRIPTION
I'm testing DietPi and enjoying speed. My changes are to allow the installation to work correctly in this distribution. I also check the existence of the splash.png file, since the default installation of the distribution is without the graphical environment, just like the Raspbian Lite.
Sorry for my bad English.