### PR TITLE
fix AttributeError: NoneType' object has no attribute 'ChangeDutyCycle

### DIFF
--- a/modules/base_plugins/gpio_actor/__init__.py
+++ b/modules/base_plugins/gpio_actor/__init__.py
@@ -44,16 +44,16 @@ class GPIOPWM(ActorBase):
     def init(self):
         GPIO.setup(int(self.gpio), GPIO.OUT)
         GPIO.output(int(self.gpio), 0)
+        if self.frequency is None:
+            self.frequency = 0.5  # 2 sec
+
+        self.p = GPIO.PWM(int(self.gpio), float(self.frequency))
 
 
     def on(self, power=None):
         if power is not None:
             self.power = int(power)
-
-        if self.frequency is None:
-            self.frequency = 0.5  # 2 sec
-
-        self.p = GPIO.PWM(int(self.gpio), float(self.frequency))
+        print "GPIO ON"
         self.p.start(int(self.power))
 
     def set_power(self, power):


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1988, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1641, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1544, in handle_user_exception
    reraise(exc_type, exc_value, tb)
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1639, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python2.7/dist-packages/flask/app.py", line 1625, in dispatch_request
    return self.view_functions[rule.endpoint](**req.view_args)
  File "/usr/local/lib/python2.7/dist-packages/flask_classy.py", line 200, in proxy
    response = view(**request.view_args)
  File "/home/pi/craftbeerpi3/modules/actor/__init__.py", line 39, in power
    self.api.actor_power(id, power)
  File "/home/pi/craftbeerpi3/modules/core/core.py", line 68, in actor_power
    actor.instance.set_power(power=power)
  File "/home/pi/craftbeerpi3/modules/base_plugins/gpio_actor/__init__.py", line 67, in set_power
    self.p.ChangeDutyCycle(self.power)
AttributeError: 'NoneType' object has no attribute 'ChangeDutyCycle'