### PR TITLE
Improve robustness of Fermentation Hysteresis

### DIFF
--- a/modules/base_plugins/fermenter_hysteresis/__init__.py
+++ b/modules/base_plugins/fermenter_hysteresis/__init__.py
@@ -20,19 +20,27 @@ class Hysteresis(FermenterController):
     def run(self):
         while self.is_running():
 
-            target_temp = self.get_target_temp()
-            temp = self.get_temp()
+            try:
 
-            if temp + float(self.heater_offset_min) <= target_temp:
-                self.heater_on(100)
+                target_temp = self.get_target_temp()
+                temp = self.get_temp()
 
-            if temp + float(self.heater_offset_max) >= target_temp:
-                self.heater_off()
+                if target_temp is not None and temp is not None:
 
-            if temp >= target_temp + float(self.cooler_offset_min):
-                self.cooler_on(100)
+                    if temp + float(self.heater_offset_min) <= target_temp:
+                        self.heater_on(100)
 
-            if temp <= target_temp + float(self.cooler_offset_max):
-                self.cooler_off()
+                    if temp + float(self.heater_offset_max) >= target_temp:
+                        self.heater_off()
+
+                    if temp >= target_temp + float(self.cooler_offset_min):
+                        self.cooler_on(100)
+
+                    if temp <= target_temp + float(self.cooler_offset_max):
+                        self.cooler_off()
+
+            except Exception as e:
+                cbpi.notify("Fermentation Loop Stuck", "Please check the CraftBeerPi system.\r\nError %s" % (str(e)), type="danger", timeout=None)
+                self.sleep(60)
 
             self.sleep(1)


### PR DESCRIPTION
- only execute the fermentation hysteresis logic if both actual and target temp are available
- surround everything by a try/except block to catch issues and to notify the user that Fermentation logic is not working