### PR TITLE
check_hop_timer skip empty values

### DIFF
--- a/modules/base_plugins/brew_steps/__init__.py
+++ b/modules/base_plugins/brew_steps/__init__.py
@@ -201,8 +201,8 @@ class BoilStep(StepBase):
 
 
     def check_hop_timer(self, number, value):
-
-        if self.__getattribute__("hop_%s_added" % number) is not True and time.time() > (
+        if isinstance(value, int) and \
+            self.__getattribute__("hop_%s_added" % number) is not True and time.time() > (
             self.timer_end - (int(self.timer) * 60 - int(value) * 60)):
             self.__setattr__("hop_%s_added" % number, True)
             self.notify("Hop Alert", "Please add Hop %s" % number, timeout=None)


### PR DESCRIPTION
At boil if some "hop addition" field is left blank the code that checks it fails and the boil step never ends, that is a huge problem on unattended brews because the heater never gets turned off.
