### PR TITLE
compile error @greenlet && downgrading gitdb2 to version 2.0.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ Werkzeug==0.11.10
 httplib2==0.9.2
 flask-classy==0.6.10
 GitPython==2.1.3
+gitdb2==2.0.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==0.12.4
 Flask-SocketIO==2.6.2
 eventlet==0.19.0
-greenlet==0.4.10
+greenlet==0.4.15
 python-dateutil==2.5.3
 python-engineio==0.9.2
 python-mimeparse==1.5.2


### PR DESCRIPTION
Hi Manuel,

bei der version 3 bekomme ich mit:
 - greenlet 0.4.10 einen Compiler-Abbruch; da schafft 0.4.15 Abhilfe,
 - gitdb2 verlangt die version 3.4 und bleibt hängen wegen python 2.7.x; da hilft der downgrade auf 2.0.5,
 - von Hand habe ich noch flask_socketio && flask_classy installiert; warum auch immer, vielleicht magst das auch anpassen - habe ich noch nicht.

Grüße
Christian