### PR TITLE
Update GitPython to 2.1.15, python2.7 compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ requests==2.20.0
 Werkzeug==0.11.10
 httplib2==0.9.2
 flask-classy==0.6.10
-GitPython==2.1.3
+GitPython==2.1.15


### PR DESCRIPTION
GitPython 2.1.15 has been reworked to work on deprecated python 2.7, as noted here:
https://github.com/gitpython-developers/GitPython/issues/897